### PR TITLE
Change default search engine to Google for en-US

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -373,9 +373,9 @@ pref("browser.search.geoSpecificDefaults", false);
 pref("browser.search.geoSpecificDefaults.url", "");
 
 // US specific default (used as a fallback if the geoSpecificDefaults request fails).
-pref("browser.search.defaultenginename.US",      "data:text/plain,browser.search.defaultenginename.US=Yahoo");
-pref("browser.search.order.US.1",                "data:text/plain,browser.search.order.US.1=Yahoo");
-pref("browser.search.order.US.2",                "data:text/plain,browser.search.order.US.2=Google");
+pref("browser.search.defaultenginename.US",      "data:text/plain,browser.search.defaultenginename.US=Google");
+pref("browser.search.order.US.1",                "data:text/plain,browser.search.order.US.1=Google");
+pref("browser.search.order.US.2",                "data:text/plain,browser.search.order.US.2=Yahoo");
 pref("browser.search.order.US.3",                "data:text/plain,browser.search.order.US.3=Bing");
 
 // search bar results always open in a new tab

--- a/browser/locales/en-US/firefox-l10n.js
+++ b/browser/locales/en-US/firefox-l10n.js
@@ -6,6 +6,6 @@
 
 # LOCALIZATION NOTE: this preference is set to true for en-US specifically,
 # locales without this line have the setting set to false by default.
-pref("browser.search.geoSpecificDefaults", true);
+pref("browser.search.geoSpecificDefaults", false);
 
 pref("general.useragent.locale", "@AB_CD@");


### PR DESCRIPTION
Changes the default search engine from Yahoo to Google for US users and ensures that the setting persists between restarts.